### PR TITLE
feat: allow to use web-fs in worker

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ web-sys = { version = "0.3", features = [
     "FileSystemWritableFileStream",
     "FileSystemGetDirectoryOptions",
     "FileSystemRemoveOptions",
+    "WorkerGlobalScope",
+    "WorkerNavigator",
 ] }
 js-sys = "0.3"
 futures-lite = "2"

--- a/src/c_static_str.rs
+++ b/src/c_static_str.rs
@@ -1,0 +1,34 @@
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(thread_local, static_string)]
+    static OPEN: JsString = "Open";
+    #[wasm_bindgen(thread_local, static_string)]
+    static READ: JsString = "Read";
+    #[wasm_bindgen(thread_local, static_string)]
+    static WRITE: JsString = "Write";
+    #[wasm_bindgen(thread_local, static_string)]
+    static CLOSE: JsString = "Close";
+    #[wasm_bindgen(thread_local, static_string)]
+    static FLUSH: JsString = "Flush";
+    #[wasm_bindgen(thread_local, static_string)]
+    static TRUNCATE: JsString = "Truncate";
+    #[wasm_bindgen(thread_local, static_string)]
+    static DROP: JsString = "Drop";
+
+    #[wasm_bindgen(thread_local, static_string)]
+    static INDEX: JsString = "index";
+    #[wasm_bindgen(thread_local, static_string)]
+    static FD: JsString = "fd";
+    #[wasm_bindgen(thread_local, static_string)]
+    static BUF: JsString = "buf";
+    #[wasm_bindgen(thread_local, static_string)]
+    static SIZE: JsString = "size";
+    #[wasm_bindgen(thread_local, static_string)]
+    static ERROR: JsString = "error";
+    #[wasm_bindgen(thread_local, static_string)]
+    static OPTIONS: JsString = "options";
+    #[wasm_bindgen(thread_local, static_string)]
+    static HANDLE: JsString = "handle";
+    #[wasm_bindgen(thread_local, static_string)]
+    static CURSOR: JsString = "cursor";
+}

--- a/tests/read_write.rs
+++ b/tests/read_write.rs
@@ -1,16 +1,20 @@
+// This only runs in the browser
+#![cfg(target_arch = "wasm32")]
+
 use futures_lite::{AsyncReadExt, AsyncWriteExt};
 use wasm_bindgen_test::*;
 
 use wasm_bindgen_test::wasm_bindgen_test_configure;
 
 wasm_bindgen_test_configure!(run_in_browser);
+wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
 use web_fs::*;
 
 #[wasm_bindgen_test]
 async fn read_write() {
-    use futures_lite::AsyncWriteExt;
     use futures_lite::AsyncReadExt;
+    use futures_lite::AsyncWriteExt;
     // write
     {
         let mut file = File::create("testf").await.unwrap();
@@ -25,7 +29,12 @@ async fn read_write() {
     }
     // append
     {
-        let mut file = OpenOptions::new().write(true).append(true).open("testf").await.unwrap();
+        let mut file = OpenOptions::new()
+            .write(true)
+            .append(true)
+            .open("testf")
+            .await
+            .unwrap();
         file.write_all(" world!".as_bytes()).await.unwrap();
     }
     {
@@ -45,7 +54,12 @@ async fn read_write() {
     }
     // truncate
     {
-        let mut file = OpenOptions::new().write(true).read(true).open("testf").await.unwrap();
+        let mut file = OpenOptions::new()
+            .write(true)
+            .read(true)
+            .open("testf")
+            .await
+            .unwrap();
         file.set_len(5).await.unwrap();
         let mut buf = String::new();
         file.read_to_string(&mut buf).await.unwrap();


### PR DESCRIPTION
Multiple things I addressed in that PR
- `rustfmt` was removing the static strings so I extracted them to the `c_static_str.rs` file and not it's possible to format without any issue
- not being able to fetch the storage doesn't panic anymore but returns an error instead
- depending on `window` being accessible or not, it fall backs on `WorkerGlobalScope` instead.

Possible future improvement
- move the use of `WorkerGlobalScope` and `window` into a feature so that it's not always enabled

Fixes #1 